### PR TITLE
added native accessors to the blake2b hash with test functions and be…

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -57,6 +57,31 @@ func BenchmarkComparisonBlake2B(b *testing.B) {
 	benchmarkHash(b, New512)
 }
 
+//replicate what the others are doing, just don't use interfaces
+func BenchmarkComparisonBlake2BNative(b *testing.B) {
+	b.SetBytes(1024 * 1024)
+	var data [1024]byte
+	for i := 0; i < b.N; i++ {
+		h := NewNative512()
+		for j := 0; j < 1024; j++ {
+			h.Write(data[:])
+		}
+		h.Sum(nil)
+	}
+}
+
+// Benchmark blake2b implementation.
+var benchNative = NewNative512()
+
+func benchmarkNativeSize(b *testing.B, size int) {
+	b.SetBytes(int64(size))
+	for i := 0; i < b.N; i++ {
+		benchNative.Reset()
+		benchNative.Write(buf[:size])
+		benchNative.Sum(nil)
+	}
+}
+
 // Benchmark blake2b implementation.
 var bench = New512()
 var buf [128 * 1024]byte
@@ -75,9 +100,19 @@ func BenchmarkSize64(b *testing.B) {
 	benchmarkSize(b, 64)
 }
 
+// Benchmark writes of 64 bytes.
+func BenchmarkSize64Native(b *testing.B) {
+	benchmarkNativeSize(b, 64)
+}
+
 // Benchmark writes of 128 bytes.
 func BenchmarkSize128(b *testing.B) {
 	benchmarkSize(b, 128)
+}
+
+// Benchmark writes of 128 bytes.
+func BenchmarkSize128Native(b *testing.B) {
+	benchmarkNativeSize(b, 128)
 }
 
 // Benchmark writes of 1KiB bytes.
@@ -85,9 +120,19 @@ func BenchmarkSize1K(b *testing.B) {
 	benchmarkSize(b, 1024)
 }
 
+// Benchmark writes of 1KiB bytes.
+func BenchmarkSize1KNative(b *testing.B) {
+	benchmarkNativeSize(b, 1024)
+}
+
 // Benchmark writes of 8KiB bytes.
 func BenchmarkSize8K(b *testing.B) {
 	benchmarkSize(b, 8*1024)
+}
+
+// Benchmark writes of 8KiB bytes.
+func BenchmarkSize8KNative(b *testing.B) {
+	benchmarkNativeSize(b, 8*1024)
 }
 
 // Benchmark writes of 32KiB bytes.
@@ -95,7 +140,17 @@ func BenchmarkSize32K(b *testing.B) {
 	benchmarkSize(b, 32*1024)
 }
 
+// Benchmark writes of 32KiB bytes.
+func BenchmarkSize32KNative(b *testing.B) {
+	benchmarkNativeSize(b, 32*1024)
+}
+
 // Benchmark writes of 128KiB bytes.
 func BenchmarkSize128K(b *testing.B) {
 	benchmarkSize(b, 128*1024)
+}
+
+// Benchmark writes of 128KiB bytes.
+func BenchmarkSize128KNative(b *testing.B) {
+	benchmarkNativeSize(b, 128*1024)
 }

--- a/blake2b.go
+++ b/blake2b.go
@@ -36,6 +36,10 @@ type digest struct {
 	isLastNode bool            // indicates processing of the last node in tree hashing
 }
 
+type Digest struct {
+	digest
+}
+
 // Initialization values.
 var iv = [8]uint64{
 	0x6a09e667f3bcc908, 0xbb67ae8584caa73b,
@@ -168,6 +172,19 @@ func New512() hash.Hash {
 	d := new(digest)
 	d.initialize(defaultConfig)
 	return d
+}
+
+//NewNative512 returns the exported Digest type
+//just a hack job to avoid using interfaces
+//And so we can get the the static type [64]byte back on Sum
+func NewNative512() *Digest {
+	d := new(Digest)
+	d.initialize(defaultConfig)
+	return d
+}
+
+func (d *Digest) Sum(in []byte) [64]byte {
+	return d.checkSum()
 }
 
 // New256 returns a new hash.Hash computing the BLAKE2b 32-byte checksum.

--- a/blake2b_test.go
+++ b/blake2b_test.go
@@ -43,6 +43,27 @@ func TestSum(t *testing.T) {
 	}
 }
 
+// TestNativeSum - tests and validates golden set of values against
+// pre-defined set of inputs and matches blake2b output.
+func TestNativeSum(t *testing.T) {
+	buf := make([]byte, len(golden))
+	for i := range buf {
+		buf[i] = byte(i)
+	}
+	h := NewNative512()
+	for i, v := range golden {
+		if v != fmt.Sprintf("%x", Sum512(buf[:i])) {
+			t.Errorf("%d: Sum512(): \nexpected %s\ngot      %x", i, v, Sum512(buf[:i]))
+		}
+		h.Reset()
+		h.Write(buf[:i])
+		sum := h.Sum(nil)
+		if fmt.Sprintf("%x", sum) != v {
+			t.Errorf("%d:\nexpected %s\ngot      %x", i, v, sum)
+		}
+	}
+}
+
 func TestSum256(t *testing.T) {
 	// Simple one-hash test.
 	in := "The cryptographic hash function BLAKE2 is an improved version of the SHA-3 finalist BLAKE"


### PR DESCRIPTION
Added native (non-interface)  methods to the blake2b hash and benchmarks.  Basically allows for access to without interfaces.

I am using the Blake2B implementation to act as a keying system for a map, so I needed a method to get constant sized hash results.  As a side effect it allows interface-free methods which can provide a small speed bump.  Figured I would throw a pull request, but if it doesn't fit with the design methodology refuse the pull.

Thanks for the implementation, its awesome.